### PR TITLE
Bye dependabot.yml.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
We decided to use Mend Renovate.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
